### PR TITLE
Fix implicit calls to strcmp()

### DIFF
--- a/fixdecifs.c
+++ b/fixdecifs.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 //#ifdef QNX
 #include <stdarg.h>

--- a/fixencifs.c
+++ b/fixencifs.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 #include "sys/image.h"
 #include "sys/startup.h"
 


### PR DESCRIPTION
The files [fixdecifs.c](https://github.com/ttepatti/dumpifs-linux/blob/implicit-fixes/fixdecifs.c) and [fixencifs.c](https://github.com/ttepatti/dumpifs-linux/blob/implicit-fixes/fixencifs.c) both contain implicit references to `strcmp()`, which cause the compilation process to throw errors:

```
fixdecifs.c:172:24: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if(3 == argc && (0 == strcmp("Y", argv[2])))
                              ^
fixdecifs.c:172:24: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
```

```
fixencifs.c:181:24: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if(3 == argc && (0 == strcmp("Y", argv[2])))
                              ^
fixencifs.c:181:24: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
```

This can be remediated by simply adding `#include <string.h>` to the top of both source files.